### PR TITLE
Fix for get_memory_format(device)

### DIFF
--- a/src/animatediff/utils/device.py
+++ b/src/animatediff/utils/device.py
@@ -99,6 +99,8 @@ def get_memory_format(device: Union[str, torch.device]) -> torch.memory_format:
         # Volta and newer seem to like channels_last. This will probably bite me on TU11x cards.
         if device_info.major >= 7:
             ret = torch.channels_last
+        else:
+            ret = torch.contiguous_format
     elif device.type == "xpu":
         # Intel ARC GPUs/XPUs like channels_last
         ret = torch.channels_last
@@ -107,3 +109,4 @@ def get_memory_format(device: Union[str, torch.device]) -> torch.memory_format:
         ret = torch.contiguous_format
     if ret == torch.channels_last:
         logger.info("Using channels_last memory format for UNet and VAE")
+    return ret


### PR DESCRIPTION
- make sure channel format is actually returned (instead of the default None if a function doesn't have a return statement)
- fix 'variable referenced before assignment' for devices with version less than 7 (e.g. GTX 1080 Ti)