### PR TITLE
add callback to save preview videos partway through diffusion

### DIFF
--- a/config/prompts/prompt_travel_multi_controlnet.json
+++ b/config/prompts/prompt_travel_multi_controlnet.json
@@ -228,6 +228,7 @@
     }
   },
   "output":{
+    "preview_steps": [10],
     "format" : "gif",
     "fps" : 8,
     "encode_param":{

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,13 @@ requires = ["setuptools>=46.4.0", "wheel", "setuptools_scm[toml]>=6.2"]
 write_to = "src/animatediff/_version.py"
 
 [tool.black]
-line-length = 120
+line-length = 110
 target-version = ['py310']
 ignore = ['F841', 'F401', 'E501']
 preview = true
 
 [tool.ruff]
-line-length = 120
+line-length = 110
 target-version = 'py310'
 ignore = ['F841', 'F401', 'E501']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,13 @@ requires = ["setuptools>=46.4.0", "wheel", "setuptools_scm[toml]>=6.2"]
 write_to = "src/animatediff/_version.py"
 
 [tool.black]
-line-length = 110
+line-length = 120
 target-version = ['py310']
 ignore = ['F841', 'F401', 'E501']
+preview = true
 
 [tool.ruff]
-line-length = 110
+line-length = 120
 target-version = 'py310'
 ignore = ['F841', 'F401', 'E501']
 

--- a/src/animatediff/generate.py
+++ b/src/animatediff/generate.py
@@ -1129,7 +1129,7 @@ def run_inference(
     # Trim and clean up the prompt for filename use
     prompt_map = region_condi_list[0]["prompt_map"]
     prompt_tags = [re_clean_prompt.sub("", tag).strip().replace(" ", "-") for tag in prompt_map[list(prompt_map.keys())[0]].split(",")]
-    prompt_str = "_".join((prompt_tags[:6]))[:100]
+    prompt_str = "_".join((prompt_tags[:6]))[:50]
     frame_dir = out_dir.joinpath(f"{idx:02d}-{seed}")
     out_file = out_dir.joinpath(f"{idx:02d}_{seed}_{prompt_str}")
 
@@ -1137,7 +1137,7 @@ def run_inference(
         save_fn(video, out_file=Path(f"{out_file}_preview@{i}"))
 
     save_fn = partial(
-        save_output, 
+        save_output,
         frame_dir=frame_dir,
         output_map=output_map,
         no_frames=no_frames,
@@ -1178,7 +1178,7 @@ def run_inference(
         interpolation_factor=1,
         is_single_prompt_mode=is_single_prompt_mode,
         callback=callback,
-        callback_steps=output_map["preview_steps"],
+        callback_steps=output_map.get("preview_steps"),
     )
     logger.info("Generation complete, saving...")
 

--- a/src/animatediff/generate.py
+++ b/src/animatediff/generate.py
@@ -1129,7 +1129,7 @@ def run_inference(
     # Trim and clean up the prompt for filename use
     prompt_map = region_condi_list[0]["prompt_map"]
     prompt_tags = [re_clean_prompt.sub("", tag).strip().replace(" ", "-") for tag in prompt_map[list(prompt_map.keys())[0]].split(",")]
-    prompt_str = "_".join((prompt_tags[:6]))[:50]
+    prompt_str = "_".join((prompt_tags[:6]))[:100]
     frame_dir = out_dir.joinpath(f"{idx:02d}-{seed}")
     out_file = out_dir.joinpath(f"{idx:02d}_{seed}_{prompt_str}")
 

--- a/src/animatediff/generate.py
+++ b/src/animatediff/generate.py
@@ -2,9 +2,11 @@ import glob
 import logging
 import os
 import re
+from functools import partial
+from itertools import chain
 from os import PathLike
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Any, Callable, Dict, List, Union
 
 import numpy as np
 import torch
@@ -17,6 +19,7 @@ from diffusers import (AutoencoderKL, ControlNetModel, DiffusionPipeline,
                        StableDiffusionControlNetImg2ImgPipeline,
                        StableDiffusionPipeline)
 from PIL import Image
+from torchvision.datasets.folder import IMG_EXTENSIONS
 from tqdm.rich import tqdm
 from transformers import (AutoImageProcessor, CLIPImageProcessor,
                           CLIPTextModel, CLIPTokenizer,
@@ -709,7 +712,7 @@ def ip_adapter_preprocess(
         if ip_adapter_config_map["enable"] == True:
             resized_to_square = ip_adapter_config_map["resized_to_square"] if "resized_to_square" in ip_adapter_config_map else False
             image_dir = data_dir.joinpath( ip_adapter_config_map["input_image_dir"] )
-            imgs = sorted(glob.glob( os.path.join(image_dir, "[0-9]*.png"), recursive=False))
+            imgs = sorted(chain.from_iterable([glob.glob(os.path.join(image_dir, f"[0-9]*{ext}")) for ext in IMG_EXTENSIONS]))
             if len(imgs) > 0:
                 prepare_ip_adapter()
                 ip_adapter_map["images"] = {}
@@ -1123,12 +1126,30 @@ def run_inference(
 ):
     out_dir = Path(out_dir)  # ensure out_dir is a Path
 
+    # Trim and clean up the prompt for filename use
+    prompt_map = region_condi_list[0]["prompt_map"]
+    prompt_tags = [re_clean_prompt.sub("", tag).strip().replace(" ", "-") for tag in prompt_map[list(prompt_map.keys())[0]].split(",")]
+    prompt_str = "_".join((prompt_tags[:6]))[:50]
+    frame_dir = out_dir.joinpath(f"{idx:02d}-{seed}")
+    out_file = out_dir.joinpath(f"{idx:02d}_{seed}_{prompt_str}")
+
+    def preview_callback(i: int, video: torch.Tensor, save_fn: Callable[[torch.Tensor], None], out_file: str) -> None:
+        save_fn(video, out_file=Path(f"{out_file}_preview@{i}"))
+
+    save_fn = partial(
+        save_output, 
+        frame_dir=frame_dir,
+        output_map=output_map,
+        no_frames=no_frames,
+        save_frames=partial(save_frames, show_progress=False),
+        save_video=save_video
+    )
+    callback = partial(preview_callback, save_fn=save_fn, out_file=out_file)
+
     seed_everything(seed)
 
     logger.info(f"{len( region_condi_list )=}")
-#    logger.info(f"{region_condi_list=}")
     logger.info(f"{len( region_list )=}")
-#    logger.info(f"{region_list=}")
 
     pipeline_output = pipeline(
         negative_prompt=n_prompt,
@@ -1156,20 +1177,12 @@ def run_inference(
         region_condi_list=region_condi_list,
         interpolation_factor=1,
         is_single_prompt_mode=is_single_prompt_mode,
+        callback=callback,
+        callback_steps=output_map["preview_steps"],
     )
-
     logger.info("Generation complete, saving...")
 
-    prompt_map = region_condi_list[0]["prompt_map"]
-
-    # Trim and clean up the prompt for filename use
-    prompt_tags = [re_clean_prompt.sub("", tag).strip().replace(" ", "-") for tag in prompt_map[list(prompt_map.keys())[0]].split(",")]
-    prompt_str = "_".join((prompt_tags[:6]))[:50]
-
-    frame_dir = out_dir.joinpath(f"{idx:02d}-{seed}")
-    out_file = out_dir.joinpath(f"{idx:02d}_{seed}_{prompt_str}")
-
-    save_output( pipeline_output, frame_dir, out_file, output_map, no_frames, save_frames, save_video )
+    save_fn(pipeline_output, out_file=out_file)
 
     logger.info(f"Saved sample to {out_file}")
     return pipeline_output

--- a/src/animatediff/rife/ffmpeg.py
+++ b/src/animatediff/rife/ffmpeg.py
@@ -203,7 +203,7 @@ class FfmpegEncoder:
 
         param = {
             "pix_fmt":"yuv420p",
-            "vcodec":"libx265",
+            "vcodec":"libx264",
             "crf":21,
             "tune":"animation",
         }
@@ -221,7 +221,7 @@ class FfmpegEncoder:
 
         param = {
             "pix_fmt":"yuv420p",
-            "vcodec":"libx265",
+            "vcodec":"libx264",
             "crf":21,
             "tune":"animation",
         }

--- a/src/animatediff/settings.py
+++ b/src/animatediff/settings.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from functools import lru_cache
 from os import PathLike
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Union
@@ -85,7 +84,6 @@ class InferenceConfig(BaseSettings):
         json_config_path: Path
 
 
-@lru_cache(maxsize=2)
 def get_infer_config(
     is_v2:bool,
 ) -> InferenceConfig:
@@ -132,7 +130,6 @@ class ModelConfig(BaseSettings):
         return f"{self.name.lower()}-{self.path.stem.lower()}"
 
 
-@lru_cache(maxsize=2)
 def get_model_config(config_path: Path) -> ModelConfig:
     settings = ModelConfig(json_config_path=config_path)
     return settings


### PR DESCRIPTION
Addresses #122 

### Previews!

The output section of the config now has a 'preview_steps' list where you can specify what steps to save preview videos at.

The previews definitely aren't perfect, but at 10 steps you can really start to get an idea of the final video.

Previews are better for models trained with v-diffusion or Karras et al.'s diffusion objectives.

Hopefully at some point in the future Stability will use these better approaches, but for now we're stuck with blurry epsilon denoising...

Video after 2 steps:

https://github.com/s9roll7/animatediff-cli-prompt-travel/assets/15871226/6241744c-55f0-47c3-8033-a2dde562045c

Video after 10 steps:

https://github.com/s9roll7/animatediff-cli-prompt-travel/assets/15871226/222d270c-2d36-4711-9782-665d275b6a1b

Final video after 25 steps:

https://github.com/s9roll7/animatediff-cli-prompt-travel/assets/15871226/dd7873aa-d7a8-4529-916e-92c82d098d93


### Other fixes

- decoding latents now moves frames straight to CPU so you don't have to keep the entire full-sized video in VRAM (probably a fix for OOM in #121) 
- IP Adapter can now read files other than .png
- use libx264 beacause it's more widely supported
- lru_caches save like 0.01 second at start-up but can silently make your config not work, so removed...